### PR TITLE
Add salary field to job prospect feature

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -37,6 +37,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       notes: "",
+      targetSalary: null,
     },
   });
 
@@ -86,24 +87,47 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="jobUrl"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Job URL (optional)</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="https://..."
-                  {...field}
-                  value={field.value ?? ""}
-                  data-testid="input-job-url"
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="jobUrl"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Job URL (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="https://..."
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-job-url"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="targetSalary"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Target Salary (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min="1"
+                    placeholder="e.g. 120000"
+                    data-testid="input-target-salary"
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <div className="grid grid-cols-2 gap-4">
           <FormField

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -42,6 +42,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
+      targetSalary: prospect.targetSalary ?? null,
     },
   });
 
@@ -90,24 +91,47 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="jobUrl"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Job URL (optional)</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="https://..."
-                  {...field}
-                  value={field.value ?? ""}
-                  data-testid="input-edit-job-url"
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="jobUrl"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Job URL (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="https://..."
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-edit-job-url"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="targetSalary"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Target Salary (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min="1"
+                    placeholder="e.g. 120000"
+                    data-testid="input-edit-target-salary"
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <div className="grid grid-cols-2 gap-4">
           <FormField

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,15 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.targetSalary != null && (
+            <span
+              className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+              data-testid={`text-salary-${prospect.id}`}
+            >
+              <DollarSign className="w-3 h-3" />
+              {prospect.targetSalary.toLocaleString()}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/server/__tests__/salary-validation.test.ts
+++ b/server/__tests__/salary-validation.test.ts
@@ -1,0 +1,52 @@
+import { validateProspect } from "../prospect-helpers";
+
+describe("salary validation", () => {
+  const base = { companyName: "Acme", roleTitle: "Engineer" };
+
+  test("accepts a valid positive integer salary", () => {
+    const result = validateProspect({ ...base, targetSalary: 120000 });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts when salary is omitted (optional)", () => {
+    const result = validateProspect({ ...base });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts when salary is null (optional)", () => {
+    const result = validateProspect({ ...base, targetSalary: null });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a negative salary", () => {
+    const result = validateProspect({ ...base, targetSalary: -5000 });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects a zero salary", () => {
+    const result = validateProspect({ ...base, targetSalary: 0 });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects a non-numeric salary string", () => {
+    const result = validateProspect({ ...base, targetSalary: "lots" });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("rejects a decimal salary", () => {
+    const result = validateProspect({ ...base, targetSalary: 99.5 });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+
+  test("salary errors are independent of other field errors", () => {
+    const result = validateProspect({ companyName: "", roleTitle: "", targetSalary: -1 });
+    expect(result.errors).toContain("Company name is required");
+    expect(result.errors).toContain("Role title is required");
+    expect(result.errors).toContain("Salary must be a positive whole number");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,13 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.targetSalary !== undefined && data.targetSalary !== null) {
+    const salary = Number(data.targetSalary);
+    if (isNaN(salary) || !Number.isInteger(salary) || salary <= 0) {
+      errors.push("Salary must be a positive whole number");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -40,6 +40,19 @@ export async function registerRoutes(
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
 
+    if (body.targetSalary !== undefined) {
+      const raw = body.targetSalary;
+      if (raw === null || raw === "") {
+        updates.targetSalary = null;
+      } else {
+        const salary = Number(raw);
+        if (isNaN(salary) || !Number.isInteger(salary) || salary <= 0) {
+          return res.status(400).json({ message: "Salary must be a positive whole number" });
+        }
+        updates.targetSalary = salary;
+      }
+    }
+
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {
         return res.status(400).json({ message: `Status must be one of: ${STATUSES.join(", ")}` });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -22,6 +22,7 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  targetSalary: integer("target_salary"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -35,6 +36,14 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  targetSalary: z.preprocess(
+    (val) => {
+      if (val === "" || val === undefined || val === null) return null;
+      const n = Number(val);
+      return isNaN(n) ? val : n;
+    },
+    z.number().int().min(1, "Salary must be a positive whole number").nullable().optional(),
+  ),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Add an optional numeric 'targetSalary' field to the job prospect schema, forms, and card display. Includes server-side validation and new unit tests for salary input.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 177f5d77-8bfe-47fb-88db-105e8146a82c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 6977e9bd-8fbb-4a10-87c3-6033edf56a56
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/30262d0c-2f5e-42c8-ba47-b2c3b5292555/177f5d77-8bfe-47fb-88db-105e8146a82c/Wlj681K
Replit-Helium-Checkpoint-Created: true