### PR TITLE
Add a searchable job prospect board that filters by company name

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -4,8 +4,9 @@ import type { Prospect } from "@shared/schema";
 import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -32,10 +33,12 @@ function KanbanColumn({
   status,
   prospects,
   isLoading,
+  hasActiveSearch,
 }: {
   status: string;
   prospects: Prospect[];
   isLoading: boolean;
+  hasActiveSearch: boolean;
 }) {
   const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
 
@@ -45,6 +48,13 @@ function KanbanColumn({
       : prospects.filter((p) => p.interestLevel === interestFilter);
 
   const columnSlug = status.replace(/\s+/g, "-").toLowerCase();
+
+  const emptyMessage =
+    interestFilter !== "All"
+      ? `No ${interestFilter} interest prospects`
+      : hasActiveSearch
+        ? "No matching prospects"
+        : "No prospects";
 
   return (
     <div
@@ -92,9 +102,7 @@ function KanbanColumn({
               className="flex flex-col items-center justify-center py-8 text-center"
               data-testid={`empty-${columnSlug}`}
             >
-              <p className="text-xs text-muted-foreground">
-                {interestFilter === "All" ? "No prospects" : `No ${interestFilter} interest prospects`}
-              </p>
+              <p className="text-xs text-muted-foreground">{emptyMessage}</p>
             </div>
           ) : (
             filteredProspects.map((prospect) => (
@@ -109,14 +117,23 @@ function KanbanColumn({
 
 export default function Home() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const { data: prospects, isLoading } = useQuery<Prospect[]>({
     queryKey: ["/api/prospects"],
   });
 
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+
+  const visibleProspects = normalizedSearch
+    ? (prospects ?? []).filter((p) =>
+        p.companyName.toLowerCase().includes(normalizedSearch),
+      )
+    : (prospects ?? []);
+
   const groupedByStatus = STATUSES.reduce(
     (acc, status) => {
-      acc[status] = (prospects ?? []).filter((p) => p.status === status);
+      acc[status] = visibleProspects.filter((p) => p.status === status);
       return acc;
     },
     {} as Record<string, Prospect[]>,
@@ -142,6 +159,29 @@ export default function Home() {
                 </p>
               </div>
             </div>
+
+            <div className="relative flex-1 max-w-xs">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+              <Input
+                type="search"
+                placeholder="Search company..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-8 pr-8 h-8 text-sm"
+                data-testid="input-search-company"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  data-testid="button-clear-search"
+                  aria-label="Clear search"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
+
             <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
               <DialogTrigger asChild>
                 <Button size="sm" data-testid="button-add-prospect">
@@ -168,6 +208,7 @@ export default function Home() {
               status={status}
               prospects={groupedByStatus[status] || []}
               isLoading={isLoading}
+              hasActiveSearch={normalizedSearch.length > 0}
             />
           ))}
         </div>

--- a/server/__tests__/company-search.test.ts
+++ b/server/__tests__/company-search.test.ts
@@ -1,0 +1,64 @@
+type ProspectStub = { id: number; companyName: string; status: string };
+
+function searchByCompany(prospects: ProspectStub[], query: string): ProspectStub[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return prospects;
+  return prospects.filter((p) => p.companyName.toLowerCase().includes(normalized));
+}
+
+const sampleProspects: ProspectStub[] = [
+  { id: 1, companyName: "Google", status: "Applied" },
+  { id: 2, companyName: "Amazon", status: "Bookmarked" },
+  { id: 3, companyName: "Meta", status: "Applied" },
+  { id: 4, companyName: "Goldman Sachs", status: "Interviewing" },
+  { id: 5, companyName: "Netflix", status: "Offer" },
+];
+
+describe("company name search filter", () => {
+  test("empty query returns all prospects", () => {
+    expect(searchByCompany(sampleProspects, "")).toHaveLength(5);
+  });
+
+  test("whitespace-only query returns all prospects", () => {
+    expect(searchByCompany(sampleProspects, "   ")).toHaveLength(5);
+  });
+
+  test("exact match returns the matching prospect", () => {
+    const result = searchByCompany(sampleProspects, "Google");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+  });
+
+  test("search is case-insensitive", () => {
+    expect(searchByCompany(sampleProspects, "google")).toHaveLength(1);
+    expect(searchByCompany(sampleProspects, "GOOGLE")).toHaveLength(1);
+    expect(searchByCompany(sampleProspects, "GoOgLe")).toHaveLength(1);
+  });
+
+  test("partial match returns all matching prospects", () => {
+    const result = searchByCompany(sampleProspects, "go");
+    const ids = result.map((p) => p.id);
+    expect(ids).toContain(1);
+    expect(ids).toContain(4);
+    expect(result).toHaveLength(2);
+  });
+
+  test("query with no matches returns an empty array", () => {
+    expect(searchByCompany(sampleProspects, "OpenAI")).toHaveLength(0);
+  });
+
+  test("clearing the search (empty string) restores all prospects", () => {
+    const filtered = searchByCompany(sampleProspects, "Netflix");
+    expect(filtered).toHaveLength(1);
+    const restored = searchByCompany(sampleProspects, "");
+    expect(restored).toHaveLength(5);
+  });
+
+  test("search is independent of prospect status", () => {
+    const result = searchByCompany(sampleProspects, "a");
+    const statuses = result.map((p) => p.status);
+    expect(statuses).toContain("Bookmarked");
+    expect(statuses).toContain("Applied");
+    expect(statuses).toContain("Interviewing");
+  });
+});


### PR DESCRIPTION
Introduces a client-side search input to filter prospects by company name. Updates `home.tsx` to manage search state and apply filters before rendering columns. Adds a new test file `server/__tests__/company-search.test.ts` for search functionality.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 177f5d77-8bfe-47fb-88db-105e8146a82c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 6980dff2-398a-4064-82b6-361c0be2f6cb
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/30262d0c-2f5e-42c8-ba47-b2c3b5292555/177f5d77-8bfe-47fb-88db-105e8146a82c/Wlj681K
Replit-Helium-Checkpoint-Created: true